### PR TITLE
Special identity handling for Java models with audit logs to fix #17

### DIFF
--- a/src/main/java/org/killbill/billing/codegen/languages/KillbillJavaGenerator.java
+++ b/src/main/java/org/killbill/billing/codegen/languages/KillbillJavaGenerator.java
@@ -180,6 +180,8 @@ public class KillbillJavaGenerator extends AbstractJavaCodegen implements Codege
                     if (p.name.equals("auditLogs")) {
                         p.isInherited = true;
                         m.parent = "KillBillObject";
+                        p.vendorExtensions.put("x-ignore-for-identity", true);
+                        m.vendorExtensions.put("x-ignore-super-for-identity", true);
                         break;
                     }
                 }

--- a/src/main/resources/killbill-java/pojo.mustache
+++ b/src/main/resources/killbill-java/pojo.mustache
@@ -95,19 +95,18 @@ public class {{classname}}{{#vendorExtensions.x-entity-generic}}<E>{{/vendorExte
             return false;
         }{{#hasVars}}
         {{classname}} {{classVarName}} = ({{classname}}) o;
-        return {{#vars}}{{#isByteArray}}Arrays{{/isByteArray}}{{#isBinary}}Arrays{{/isBinary}}{{^isByteArray}}{{^isBinary}}Objects{{/isBinary}}{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
-        {{/hasMore}}{{/vars}}{{/hasVars}}{{^hasVars}}
-        return true{{/hasVars}};
-
-        {{! We don't call super.equals(o) for the audit logs}}
+        return {{#vars}}{{^vendorExtensions.x-ignore-for-identity}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-ignore-for-identity}}{{#vendorExtensions.x-ignore-for-identity}}true /* ignoring this.{{name}} for identity operations */{{/vendorExtensions.x-ignore-for-identity}}{{#hasMore}} &&
+            {{/hasMore}}{{/vars}}{{^vendorExtensions.x-ignore-super-for-identity}}{{#parent}} &&
+            super.equals(o){{/parent}}{{/vendorExtensions.x-ignore-super-for-identity}};{{/hasVars}}{{^hasVars}}
+        return true;{{/hasVars}}
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash({{#vars}}{{^isByteArray}}{{^isBinary}}{{name}}{{/isBinary}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{name}}){{/isByteArray}}{{#isBinary}}Arrays.hashCode({{name}}){{/isBinary}}{{#hasMore}},
-                            {{/hasMore}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
+        return Objects.hash({{#vars}}{{^vendorExtensions.x-ignore-for-identity}}{{name}}{{/vendorExtensions.x-ignore-for-identity}}{{#vendorExtensions.x-ignore-for-identity}}0 /* ignoring {{name}} for identity operations */ {{/vendorExtensions.x-ignore-for-identity}}{{#hasMore}},
+            {{/hasMore}}{{/vars}}{{^vendorExtensions.x-ignore-super-for-identity}}{{#parent}}{{#hasVars}},
+            {{/hasVars}}super.hashCode(){{/parent}}{{/vendorExtensions.x-ignore-super-for-identity}});
     }
-
 
     @Override
     public String toString() {

--- a/src/main/resources/killbill-java/pojo_doc.mustache
+++ b/src/main/resources/killbill-java/pojo_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isEnum}}[**{{datatypeWithEnum}}**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{datatype}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{datatype}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#readOnly}} [readonly]{{/readOnly}}
+{{#vars}}**{{name}}** | {{#isEnum}}[**{{datatypeWithEnum}}**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{datatype}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{datatype}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#readOnly}} [readonly]{{/readOnly}}{{#vendorExtensions.x-ignore-for-identity}} [non-identity]{{/vendorExtensions.x-ignore-for-identity}}
 {{/vars}}
 {{#vars}}{{#isEnum}}
 


### PR DESCRIPTION
Hi,

I finally worked on the issue, but this pull request is not as good as I hoped it to be.
Removing `KillBillObject` is quite a huge task because, for example, `KillBillObjects` uses it, too, and I'm not versed in Swagger.
So this is a "that's how far I've gotten, maybe it helps to define any next steps or find a better solution" PR, not a "problem fixed, please apply it" one.
That's why I didn't also create a PR for the client code.
So feel free to just reject it :wink:

Instead of removing the special handling, I ended up adding even more...
Regarding issue #17 it's an improvement.
But from a more general viewpoint, it's creating more technical debt.

The PR extends the special-handling to mark the property `auditLogs` to be ignored for identity functions and the model to ignore `super`. The property had to be replaced with alternative values (`true`/`0`) in `equals` and `hashCode` because the way Swagger `#hasMore` works in the templates.
The generated client-code looks fine to me, and there were no compiler issues.
I've also added a note to the generated `pojo_doc.mustache` documentation to mention fields being ignored for identity functions.

The only "real" solution I see is changing the structure/hierarchy between the models in Swagger and change **a lot** of the client code, which might break compatibility.
So it might not be the best or most practical approach to the issue.
