### PR TITLE
1615 remove guava in swagger coden

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kill Bill Client Code Generation
 
 This repository is an extension of the [swagger coden module](https://github.com/swagger-api/swagger-codegen#making-your-own-codegen-modules),
-and is used to generate our Kill Bill client libraries. It contains both a set of templates and and java modules to allow to customize the generated client library.
+and is used to generate our Kill Bill client libraries. It contains both a set of templates and java modules to allow to customize the generated client library.
 
 
 The repo was generated using the [`meta` verb from the code generator](https://github.com/swagger-api/swagger-codegen#making-your-own-codegen-modules),
@@ -87,11 +87,11 @@ The code customization allows for the following:
 
 In addition to code customization, we can also define our own Mustache templates to generate the client code we want to have.
 
-Modifying the generator, including the Mustache template would require building the repo: `mvn -DskipTests=true -Dmaven.javadoc.skip=true install`
-
 So, in summary, the `kbswagger.json` input along with the custom code and templates provide a flexible way to generate client libraries in any language.
 
+## Modifying the generator
 
+To modifying the generator, including the Mustache template would require building the repo: `mvn -DskipTests=true -Dmaven.javadoc.skip=true install`
 
 # Supported Languages
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,9 +99,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>
                 <configuration>
-                    <source>
-                    1.7</source>
-                    <target>1.7</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/org/killbill/billing/codegen/languages/KillbillJavaGenerator.java
+++ b/src/main/java/org/killbill/billing/codegen/languages/KillbillJavaGenerator.java
@@ -1,8 +1,6 @@
 package org.killbill.billing.codegen.languages;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import io.swagger.codegen.*;
 import io.swagger.codegen.languages.AbstractJavaCodegen;
@@ -126,6 +124,7 @@ public class KillbillJavaGenerator extends AbstractJavaCodegen implements Codege
 
         importMapping.clear();
         importMapping.put("UUID", "java.util.UUID");
+        importMapping.put("Collection", "java.util.Collection");
         importMapping.put("List", "java.util.List");
         importMapping.put("LinkedList", "java.util.LinkedList");
         importMapping.put("ArrayList", "java.util.ArrayList");
@@ -172,7 +171,7 @@ public class KillbillJavaGenerator extends AbstractJavaCodegen implements Codege
             Map<String, Object> modelTemplate = (Map<String, Object>) entries;
             final CodegenModel m = (CodegenModel) modelTemplate.get("model");
             if (m.name.equals("Entity")) {
-                return ImmutableMap.of();
+                return Collections.emptyMap();
             }
 
             final Iterator<CodegenProperty> it  = m.vars.iterator();
@@ -448,6 +447,9 @@ public class KillbillJavaGenerator extends AbstractJavaCodegen implements Codege
                 this.returnType = String.format("%ss", this.returnBaseType);
             }
             this.isStream = produces != null && !produces.isEmpty() && produces.get(0).get("mediaType").equals("application/octet-stream");
+            this.hasNonRequiredDefaultQueryParams = this.queryParams
+                    .stream()
+                    .anyMatch(input -> !input.required && input.defaultValue != null);
             this.hasNonRequiredDefaultQueryParams = Iterables.any(this.queryParams, new Predicate<CodegenParameter>() {
                 @Override
                 public boolean apply(CodegenParameter input) {

--- a/src/main/resources/killbill-java/api.mustache
+++ b/src/main/resources/killbill-java/api.mustache
@@ -17,8 +17,6 @@ import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
 
-import org.killbill.commons.utils.Preconditions;
-
 
 /**
  *           DO NOT EDIT !!!
@@ -47,6 +45,13 @@ public class {{classname}} {
         }
     }
 
+    public static <T> T checkNotNull(final T reference, final Object errorMessage) {
+        if (reference == null) {
+            throw new NullPointerException(String.valueOf(errorMessage));
+        }
+        return reference;
+    }
+
     {{#operation}}
     {{#isPost}}
     {{#hasNonRequiredDefaultQueryParams}}
@@ -64,7 +69,7 @@ public class {{classname}} {
         {{#allParams}}
         {{^isHeaderParam}}
         {{#required}}
-        Preconditions.checkNotNull({{paramName}}, "Missing the required parameter '{{paramName}}' when calling {{operationId}}");
+        checkNotNull({{paramName}}, "Missing the required parameter '{{paramName}}' when calling {{operationId}}");
         {{/required}}
         {{/isHeaderParam}}
         {{/allParams}}
@@ -128,7 +133,7 @@ public class {{classname}} {
         {{#allParams}}
         {{^isHeaderParam}}
         {{#required}}
-        Preconditions.checkNotNull({{paramName}}, "Missing the required parameter '{{paramName}}' when calling {{operationId}}");
+        checkNotNull({{paramName}}, "Missing the required parameter '{{paramName}}' when calling {{operationId}}");
         {{/required}}
         {{/isHeaderParam}}
         {{/allParams}}
@@ -186,7 +191,7 @@ public class {{classname}} {
         {{#allParams}}
         {{^isHeaderParam}}
         {{#required}}
-        Preconditions.checkNotNull({{paramName}}, "Missing the required parameter '{{paramName}}' when calling {{operationId}}");
+        checkNotNull({{paramName}}, "Missing the required parameter '{{paramName}}' when calling {{operationId}}");
         {{/required}}
         {{/isHeaderParam}}
         {{/allParams}}
@@ -234,7 +239,7 @@ public class {{classname}} {
         {{#allParams}}
         {{^isHeaderParam}}
         {{#required}}
-        Preconditions.checkNotNull({{paramName}}, "Missing the required parameter '{{paramName}}' when calling {{operationId}}");
+        checkNotNull({{paramName}}, "Missing the required parameter '{{paramName}}' when calling {{operationId}}");
         {{/required}}
         {{/isHeaderParam}}
         {{/allParams}}

--- a/src/main/resources/killbill-java/api.mustache
+++ b/src/main/resources/killbill-java/api.mustache
@@ -2,20 +2,22 @@
 
 package {{package}};
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Objects;
 
 {{#imports}}import {{import}};
 {{/imports}}
-
-import com.google.common.collect.Multimap;
-import com.google.common.base.Preconditions;
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.LinkedListMultimap;
 
 import org.killbill.billing.client.Converter;
 import org.killbill.billing.client.KillBillClientException;
 import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.RequestOptions.RequestOptionsBuilder;
+
+import org.killbill.commons.utils.Preconditions;
 
 
 /**
@@ -35,6 +37,14 @@ public class {{classname}} {
 
     public {{classname}}(final KillBillHttpClient httpClient) {
         this.httpClient = httpClient;
+    }
+
+    private <K, V> void addToMapValues(final Map<K, Collection<V>> map, final K key, final Collection<V> values) {
+        if (map.containsKey(key)) {
+            map.get(key).addAll(values);
+        } else {
+            map.put(key, values);
+        }
     }
 
     {{#operation}}
@@ -64,7 +74,7 @@ public class {{classname}} {
 
 {{>api_query}}
         final RequestOptionsBuilder inputOptionsBuilder = inputOptions.extend();
-        final Boolean followLocation = MoreObjects.firstNonNull(inputOptions.getFollowLocation(), Boolean.TRUE);
+        final Boolean followLocation = Objects.requireNonNullElse(inputOptions.getFollowLocation(), Boolean.TRUE);
         inputOptionsBuilder.withFollowLocation(followLocation);
         {{#queryParams}}
         {{#-first}}

--- a/src/main/resources/killbill-java/api_query.mustache
+++ b/src/main/resources/killbill-java/api_query.mustache
@@ -1,20 +1,20 @@
         {{#queryParams}}
         {{#-first}}
-        final Multimap<String, String> queryParams = LinkedListMultimap.create(inputOptions.getQueryParams());
+        final Map<String, Collection<String>> queryParams = new HashMap<>(inputOptions.getQueryParams());
         {{/-first}}
         {{/queryParams}}
         {{#queryParams}}
         {{#isListContainer}}
         if ({{paramName}} != null) {
             {{#isEnum}}
-            queryParams.putAll("{{baseName}}", Converter.convertEnumListToStringList({{paramName}}));
+            addToMapValues(queryParams, "{{baseName}}", Converter.convertEnumListToStringList({{paramName}}));
             {{/isEnum}}
             {{^isEnum}}
             {{#isUuid}}
-            queryParams.putAll("{{baseName}}", Converter.convertUUIDListToStringList({{paramName}}));
+            addToMapValues(queryParams, "{{baseName}}", Converter.convertUUIDListToStringList({{paramName}}));
             {{/isUuid}}
             {{^isUuid}}
-            queryParams.putAll("{{baseName}}", {{paramName}});
+            addToMapValues(queryParams, "{{baseName}}", {{paramName}});
             {{/isUuid}}
             {{/isEnum}}
         }
@@ -23,13 +23,13 @@
         {{#isMapContainer}}
         {{#isQueryPluginProperty}}
         if ({{paramName}} != null) {
-            queryParams.putAll("{{baseName}}", Converter.convertPluginPropertyMap({{paramName}}));
+            addToMapValues(queryParams, "{{baseName}}", Converter.convertPluginPropertyMap({{paramName}}));
         }
         {{/isQueryPluginProperty}}
         {{/isMapContainer}}
         {{^isMapContainer}}
         if ({{paramName}} != null) {
-            queryParams.put("{{baseName}}", String.valueOf({{paramName}}));
+            addToMapValues(queryParams, "{{baseName}}", List.of(String.valueOf({{paramName}})));
         }
         {{/isMapContainer}}
         {{/isListContainer}}


### PR DESCRIPTION
1. update compiler plugin to v.8
2. remove guava related classes in `KillbillJavaGenerator`
3. `api.mustache` having new method: `addToMapValues()` as helper to add element to existing map values (replacement of `Multimap`)
4. I know that `KillbillJavaGenerator` try to add import at runtime, but sometimes not (`List` in `api_query.mustache` is an example), Thus hardcoded import in `api.mustache`.

PR for `killbill-client-java` will be made after work on this complete.